### PR TITLE
SetFollowPathOffset Modifier to randomize the position of objects constrained to a path

### DIFF
--- a/src/catharsys/plugins/std/blender/modify/func/object_util.py
+++ b/src/catharsys/plugins/std/blender/modify/func/object_util.py
@@ -269,6 +269,20 @@ def ModifyAttributes(_objX, _dicMod, **kwargs):
 
 
 ################################################################################
+def SetFollowPathOffset(_objX, _dicMod, **kwargs):
+    """Set the offset of the Follow Path constraint of the modified object
+
+    Configuration Args:
+        fOffset (float): The offset value to set
+
+    """
+    fOffset = convert.DictElementToFloat(_dicMod, "fOffset")
+    if _objX.constraints.get("Follow Path") is None:
+        raise RuntimeError(f"Object '{_objX.name}' has no Follow Path constraint")
+    _objX.constraints["Follow Path"].offset_factor = fOffset
+
+
+################################################################################
 def ParentToObject(_objX, _dicMod, **kwargs):
     """Parent object to another
 


### PR DESCRIPTION
Implement SetFollowPathOffset modifier to manipulate the offset the f…ollow path constraint of an Object.

This can be used to randomize the position of objects that are constrained to a path.